### PR TITLE
feat: support get path and method with h2 request header

### DIFF
--- a/src/http/ngx_http_wasm_api.c
+++ b/src/http/ngx_http_wasm_api.c
@@ -12,6 +12,16 @@ typedef struct {
     ngx_str_t       value;
 } ngx_http_wasm_table_elt_t;
 
+typedef struct {
+    ngx_str_t name;
+    ngx_uint_t ty;
+} ngx_http_wasm_h2_header_t;
+
+
+enum {
+    WASM_H2_HEADER_PATH = 1,
+    WASM_H2_HEADER_METHOD,
+};
 
 #define STR_BUF_SIZE    4096
 
@@ -37,24 +47,10 @@ typedef struct {
         return NGX_ERROR; \
     }
 
-enum {
-    WASM_H2_HEADER_PATH = 1,
-    WASM_H2_HEADER_METHOD,
-};
+#define WASM_H2_HEADER_STATIC_TABLE_ENTRIES                                      \
+    (sizeof(wasm_h2_header_static_table)                                         \
+     / sizeof(ngx_http_wasm_h2_header_t))
 
-typedef struct {
-    ngx_str_t name;
-    ngx_uint_t ty;
-} ngx_wasm_h2_header_t;
-
-static ngx_wasm_h2_header_t ngx_wasm_h2_header_static_table[] = {
-        {ngx_string(":path"),   WASM_H2_HEADER_PATH},
-        {ngx_string(":method"), WASM_H2_HEADER_METHOD},
-};
-
-#define NGX_WASM_H2_HEADER_STATIC_TABLE_ENTRIES                                      \
-    (sizeof(ngx_wasm_h2_header_static_table)                                         \
-     / sizeof(ngx_wasm_h2_header_t))
 
 static int (*set_resp_header) (ngx_http_request_t *r,
     const char *key_data, size_t key_len, int is_nil,
@@ -77,6 +73,11 @@ static char *err_bad_ctx = "API disabled in the current context";
 static char *err_no_req_ctx = "no request ctx found";
 
 static char *str_buf[STR_BUF_SIZE] = {0};
+
+static ngx_http_wasm_h2_header_t wasm_h2_header_static_table[] = {
+    {ngx_string(":path"),   WASM_H2_HEADER_PATH},
+    {ngx_string(":method"), WASM_H2_HEADER_METHOD},
+};
 
 
 wasm_functype_t *
@@ -747,13 +748,14 @@ static int32_t
 ngx_http_wasm_req_get_header(ngx_http_request_t *r, char *key,  int32_t key_size,
                              int32_t addr, int32_t size)
 {
-    ngx_log_t           *log;
-    ngx_uint_t           i;
-    ngx_list_part_t     *part;
-    ngx_table_elt_t     *header;
-    unsigned char       *key_buf = NULL;
-    const u_char        *val = NULL;
-    int32_t              val_len = 0;
+    ngx_log_t                 *log;
+    ngx_uint_t                i;
+    ngx_list_part_t           *part;
+    ngx_table_elt_t           *header;
+    ngx_http_wasm_h2_header_t *wh;
+    unsigned char             *key_buf = NULL;
+    const u_char              *val = NULL;
+    int32_t                   val_len = 0;
 
     log = r->connection->log;
     part = &r->headers_in.headers.part;
@@ -780,23 +782,30 @@ ngx_http_wasm_req_get_header(ngx_http_request_t *r, char *key,  int32_t key_size
         key_buf = (u_char *) key;
     }
 
-    if (key_buf[0] == ':') {
-        for (i = 0; i < NGX_WASM_H2_HEADER_STATIC_TABLE_ENTRIES; i++) {
-            if (ngx_strncasecmp(key_buf, ngx_wasm_h2_header_static_table[i].name.data,
-                                key_size) == 0) {
+    if (key_size > 0 && key_buf[0] == ':') {
+        for (i = 0; i < WASM_H2_HEADER_STATIC_TABLE_ENTRIES; i++) {
+            wh = &wasm_h2_header_static_table[i];
 
-                switch (ngx_wasm_h2_header_static_table[i].ty) {
-                    case WASM_H2_HEADER_PATH:
-                        val = r->unparsed_uri.data;
-                        val_len = r->unparsed_uri.len;
-                        break;
-                    case WASM_H2_HEADER_METHOD:
-                        val = r->method_name.data;
-                        val_len = r->method_name.len;
-                        break;
-                        /* todo: scheme https://github.com/api7/wasm-nginx-module/issues/47 */
-                    default:
-                        break;
+            if ((size_t) key_size != wh->name.len) {
+                continue;
+            }
+
+            if (ngx_strncasecmp(key_buf, wh->name.data, wh->name.len) == 0) {
+
+                switch (wh->ty) {
+                case WASM_H2_HEADER_PATH:
+                    val = r->unparsed_uri.data;
+                    val_len = r->unparsed_uri.len;
+                    break;
+
+                case WASM_H2_HEADER_METHOD:
+                    val = r->method_name.data;
+                    val_len = r->method_name.len;
+                    break;
+
+                /* todo: scheme https://github.com/api7/wasm-nginx-module/issues/47 */
+                default:
+                    break;
                 }
 
                 if (val) break;

--- a/src/http/ngx_http_wasm_api.c
+++ b/src/http/ngx_http_wasm_api.c
@@ -799,12 +799,12 @@ ngx_http_wasm_req_get_header(ngx_http_request_t *r, char *key,  int32_t key_size
                         break;
                 }
 
-                if (val == NULL) {
-                    break;
-                }
+                if (val) break;
             }
         }
-    } else {
+    }
+
+    if (val == NULL) {
         for (i = 0; /* void */ ; i++) {
 
             if (i >= part->nelts) {

--- a/src/http/ngx_http_wasm_api.c
+++ b/src/http/ngx_http_wasm_api.c
@@ -749,13 +749,13 @@ ngx_http_wasm_req_get_header(ngx_http_request_t *r, char *key,  int32_t key_size
                              int32_t addr, int32_t size)
 {
     ngx_log_t                 *log;
-    ngx_uint_t                i;
+    ngx_uint_t                 i;
     ngx_list_part_t           *part;
     ngx_table_elt_t           *header;
     ngx_http_wasm_h2_header_t *wh;
     unsigned char             *key_buf = NULL;
     const u_char              *val = NULL;
-    int32_t                   val_len = 0;
+    int32_t                    val_len = 0;
 
     log = r->connection->log;
     part = &r->headers_in.headers.part;
@@ -808,7 +808,9 @@ ngx_http_wasm_req_get_header(ngx_http_request_t *r, char *key,  int32_t key_size
                     break;
                 }
 
-                if (val) break;
+                if (val) {
+                    break;
+                }
             }
         }
     }

--- a/src/http/ngx_http_wasm_api.c
+++ b/src/http/ngx_http_wasm_api.c
@@ -809,7 +809,7 @@ ngx_http_wasm_req_get_header(ngx_http_request_t *r, char *key,  int32_t key_size
                 }
 
                 if (val != NULL) {
-                    goto success;
+                    goto done;
                 }
             }
         }
@@ -838,17 +838,11 @@ ngx_http_wasm_req_get_header(ngx_http_request_t *r, char *key,  int32_t key_size
         if (ngx_strncasecmp(key_buf, header[i].key.data, header[i].key.len) == 0) {
             val = header[i].value.data;
             val_len = header[i].value.len;
-            goto success;
+            break;
         }
     }
 
-    if (key_buf != (u_char *) key) {
-        ngx_free(key_buf);
-    }
-
-    return ngx_http_wasm_copy_to_wasm(log, NULL, 0, addr, size);
-
-success:
+done:
 
     if (key_buf != (u_char *) key) {
         ngx_free(key_buf);

--- a/t/http_req_header.t
+++ b/t/http_req_header.t
@@ -260,7 +260,7 @@ nil
 
 
 
-=== TEST 14: get path
+=== TEST 14: get path (not args)
 --- config
 location /t {
     content_by_lua_block {
@@ -277,7 +277,26 @@ get request path: /t,
 
 
 
-=== TEST 15: get method
+=== TEST 15: get path (args)
+--- config
+location /t {
+    content_by_lua_block {
+        local wasm = require("resty.proxy-wasm")
+        local plugin = assert(wasm.load("plugin", "t/testdata/http_header/main.go.wasm"))
+        local ctx = assert(wasm.on_configure(plugin, 'req_path_get'))
+        assert(wasm.on_http_request_headers(ctx))
+    }
+}
+--- request
+GET /t?q=hello&a=world
+--- grep_error_log eval
+qr/get request path: \S+/
+--- grep_error_log_out
+get request path: /t?q=hello&a=world,
+
+
+
+=== TEST 16: get method (GET)
 --- config
 location /t {
     content_by_lua_block {
@@ -291,3 +310,60 @@ location /t {
 qr/get request method: \S+/
 --- grep_error_log_out
 get request method: GET,
+
+
+
+=== TEST 17: get method (POST)
+--- config
+location /t {
+    content_by_lua_block {
+        local wasm = require("resty.proxy-wasm")
+        local plugin = assert(wasm.load("plugin", "t/testdata/http_header/main.go.wasm"))
+        local ctx = assert(wasm.on_configure(plugin, 'req_method_get'))
+        assert(wasm.on_http_request_headers(ctx))
+    }
+}
+--- request
+POST /t
+--- grep_error_log eval
+qr/get request method: \S+/
+--- grep_error_log_out
+get request method: POST,
+
+
+
+=== TEST 18: get method (PUT)
+--- config
+location /t {
+    content_by_lua_block {
+        local wasm = require("resty.proxy-wasm")
+        local plugin = assert(wasm.load("plugin", "t/testdata/http_header/main.go.wasm"))
+        local ctx = assert(wasm.on_configure(plugin, 'req_method_get'))
+        assert(wasm.on_http_request_headers(ctx))
+    }
+}
+--- request
+PUT /t
+--- grep_error_log eval
+qr/get request method: \S+/
+--- grep_error_log_out
+get request method: PUT,
+
+
+
+=== TEST 19: get method (DELETE)
+--- config
+location /t {
+    content_by_lua_block {
+        local wasm = require("resty.proxy-wasm")
+        local plugin = assert(wasm.load("plugin", "t/testdata/http_header/main.go.wasm"))
+        local ctx = assert(wasm.on_configure(plugin, 'req_method_get'))
+        assert(wasm.on_http_request_headers(ctx))
+    }
+}
+--- request
+DELETE /t
+--- grep_error_log eval
+qr/get request method: \S+/
+--- grep_error_log_out
+get request method: DELETE,

--- a/t/http_req_header.t
+++ b/t/http_req_header.t
@@ -257,3 +257,37 @@ FOO: foo
 FOO: bar
 --- response_body
 nil
+
+
+
+=== TEST 14: get path
+--- config
+location /t {
+    content_by_lua_block {
+        local wasm = require("resty.proxy-wasm")
+        local plugin = assert(wasm.load("plugin", "t/testdata/http_header/main.go.wasm"))
+        local ctx = assert(wasm.on_configure(plugin, 'req_path_get'))
+        assert(wasm.on_http_request_headers(ctx))
+    }
+}
+--- grep_error_log eval
+qr/get request path: \S+/
+--- grep_error_log_out
+get request path: /t,
+
+
+
+=== TEST 15: get method
+--- config
+location /t {
+    content_by_lua_block {
+        local wasm = require("resty.proxy-wasm")
+        local plugin = assert(wasm.load("plugin", "t/testdata/http_header/main.go.wasm"))
+        local ctx = assert(wasm.on_configure(plugin, 'req_method_get'))
+        assert(wasm.on_http_request_headers(ctx))
+    }
+}
+--- grep_error_log eval
+qr/get request method: \S+/
+--- grep_error_log_out
+get request method: GET,

--- a/t/testdata/http_header/main.go
+++ b/t/testdata/http_header/main.go
@@ -74,6 +74,22 @@ func (ctx *httpContext) OnHttpRequestHeaders(numHeaders int, endOfStream bool) t
 
 	case "req_hdr_del":
 		proxywasm.RemoveHttpRequestHeader("foo")
+
+	case "req_path_get":
+		res, err := proxywasm.GetHttpRequestHeader(":path")
+		if err != nil {
+			proxywasm.LogErrorf("error get request path: %v", err)
+			return types.ActionContinue
+		}
+		proxywasm.LogWarnf("get request path: %v", res)
+
+	case "req_method_get":
+		res, err := proxywasm.GetHttpRequestHeader(":method")
+		if err != nil {
+			proxywasm.LogErrorf("error get request method: %v", err)
+			return types.ActionContinue
+		}
+		proxywasm.LogWarnf("get request method: %v", res)
 	}
 
 	return types.ActionContinue


### PR DESCRIPTION
FIX #48 

Another solution: when the wasm module gets the http context, adds `:path` and `:method` to the linked list of the request header, but there will be additional memory overhead. The current solution is the simplest and original implementation.