### PR TITLE
ci: add license header check

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,12 +1,10 @@
+# Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.
-# The ASF licenses this file to You under the Apache License, Version 2.0
-# (the "License"); you may not use this file except in compliance with
-# the License.  You may obtain a copy of the License at
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 root = true
 
 [*]

--- a/.github/workflows/license-checker.yml
+++ b/.github/workflows/license-checker.yml
@@ -1,0 +1,37 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+name: License checker
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-license:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+
+    steps:
+      - uses: actions/checkout@v2.4.0
+      - name: Check License Header
+        uses: apache/skywalking-eyes@v0.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -12,23 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-use t::WASM 'no_plan';
+header:
+  license:
+    spdx-id: Apache-2.0
+    copyright-owner: Shenzhen ZhiLiu Technology Co., Ltd.
 
-run_tests();
+  paths-ignore:
+    - '.gitignore'
+    - 'LICENSE'
+    - '.github/'
+    # Exclude test files
+    - 'go.mod'
+    - 'go.sum'
+    - 't/certs/'
+    - 't/testdata/assemblyscript/node_modules/'
+    - 't/testdata/assemblyscript/build/'
+    - 't/testdata/rust/Cargo.lock'
+    - '**/*.json'
+    # Exclude dev files
+    - '.ccls-cache/'
 
-__DATA__
-
-=== TEST 1: fault injection
---- config
-location /t {
-    content_by_lua_block {
-        local wasm = require("resty.proxy-wasm")
-        local plugin = assert(wasm.load("FaultInjection",
-            "t/testdata/assemblyscript/build/untouched.wasm"))
-        local ctx = assert(wasm.on_configure(plugin, 'body'))
-        assert(wasm.on_http_request_headers(ctx))
-    }
-}
---- error_code: 403
---- response_body chomp
-body
+  comment: on-failure

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,3 +1,17 @@
+-- Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
 ignore = {
     '_',
     "311",

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,17 @@
+# Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 OPENRESTY_PREFIX ?= /usr/local/openresty
 INSTALL ?= install
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+-->
 ## Status
 
 This library is under construction. See https://github.com/api7/wasm-nginx-module/issues/25 to know the progress.

--- a/config
+++ b/config
@@ -1,3 +1,17 @@
+# Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 ngx_module_type=HTTP
 ngx_module_name=ngx_http_wasm_module
 ngx_module_srcs=" \

--- a/install-wasmtime.sh
+++ b/install-wasmtime.sh
@@ -1,4 +1,18 @@
 #!/usr/bin/env bash
+# Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 set -euo pipefail -x
 
 VER=v0.30.0

--- a/lib/resty/proxy-wasm.lua
+++ b/lib/resty/proxy-wasm.lua
@@ -1,3 +1,17 @@
+-- Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+-- http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
 local ffi = require("ffi")
 local base = require("resty.core.base")
 local http = require("resty.http")

--- a/proxy_wasm_abi.md
+++ b/proxy_wasm_abi.md
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+-->
 # Proxy-Wasm ABI specification implemented in the wasm-nginx-module
 
 As this module is still WIP, this list will be changed in the future version.

--- a/src/http/ngx_http_wasm_api.c
+++ b/src/http/ngx_http_wasm_api.c
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 #define _GNU_SOURCE /* for RTLD_DEFAULT */
 #include <dlfcn.h>
 #include "vm/vm.h"

--- a/src/http/ngx_http_wasm_api.h
+++ b/src/http/ngx_http_wasm_api.h
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 #ifndef NGX_HTTP_WASM_API_H
 #define NGX_HTTP_WASM_API_H
 

--- a/src/http/ngx_http_wasm_call.c
+++ b/src/http/ngx_http_wasm_call.c
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 #include <ngx_http.h>
 #include "ngx_http_wasm_call.h"
 #include "ngx_http_wasm_ctx.h"

--- a/src/http/ngx_http_wasm_call.h
+++ b/src/http/ngx_http_wasm_call.h
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 #ifndef NGX_HTTP_WASM_CALL_H
 #define NGX_HTTP_WASM_CALL_H
 

--- a/src/http/ngx_http_wasm_ctx.h
+++ b/src/http/ngx_http_wasm_ctx.h
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 #ifndef NGX_HTTP_WASM_CTX_H
 #define NGX_HTTP_WASM_CTX_H
 

--- a/src/http/ngx_http_wasm_module.c
+++ b/src/http/ngx_http_wasm_module.c
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 #include <ngx_config.h>
 #include <ngx_core.h>
 #include <ngx_http.h>

--- a/src/http/ngx_http_wasm_module.h
+++ b/src/http/ngx_http_wasm_module.h
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 #ifndef NGX_HTTP_WASM_MODULE_H
 #define NGX_HTTP_WASM_MODULE_H
 

--- a/src/http/ngx_http_wasm_state.c
+++ b/src/http/ngx_http_wasm_state.c
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 #include "ngx_http_wasm_state.h"
 
 

--- a/src/http/ngx_http_wasm_state.h
+++ b/src/http/ngx_http_wasm_state.h
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 #ifndef NGX_HTTP_WASM_STATE_H
 #define NGX_HTTP_WASM_STATE_H
 

--- a/src/proxy_wasm/proxy_wasm_map.c
+++ b/src/proxy_wasm/proxy_wasm_map.c
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 #include "proxy_wasm_map.h"
 
 

--- a/src/proxy_wasm/proxy_wasm_map.h
+++ b/src/proxy_wasm/proxy_wasm_map.h
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 #ifndef PROXY_WASM_MAP_H
 #define PROXY_WASM_MAP_H
 #include <stdbool.h>

--- a/src/proxy_wasm/proxy_wasm_types.h
+++ b/src/proxy_wasm/proxy_wasm_types.h
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 #ifndef PROXY_WASM_TYPES_H
 #define PROXY_WASM_TYPES_H
 

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 #include "vm.h"
 
 

--- a/src/vm/vm.h
+++ b/src/vm/vm.h
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 #ifndef VM_H
 #define VM_H
 

--- a/src/vm/wasmtime.c
+++ b/src/vm/wasmtime.c
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 #include <wasi.h>
 #include <wasm.h>
 #include <wasmtime.h>

--- a/t/WASM.pm
+++ b/t/WASM.pm
@@ -1,3 +1,17 @@
+# Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 package t::WASM;
 
 use Test::Nginx::Socket::Lua;

--- a/t/http_call.t
+++ b/t/http_call.t
@@ -1,3 +1,17 @@
+# Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 use t::WASM 'no_plan';
 
 run_tests();

--- a/t/http_call_callback.t
+++ b/t/http_call_callback.t
@@ -1,3 +1,17 @@
+# Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 use t::WASM 'no_plan';
 
 run_tests();

--- a/t/http_call_multi.t
+++ b/t/http_call_multi.t
@@ -1,3 +1,17 @@
+# Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 use t::WASM 'no_plan';
 
 run_tests();

--- a/t/http_lifecycle.t
+++ b/t/http_lifecycle.t
@@ -1,3 +1,17 @@
+# Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 use t::WASM 'no_plan';
 
 run_tests();

--- a/t/http_req_header.t
+++ b/t/http_req_header.t
@@ -1,3 +1,17 @@
+# Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 use t::WASM 'no_plan';
 
 run_tests();

--- a/t/http_resp_header.t
+++ b/t/http_resp_header.t
@@ -1,3 +1,17 @@
+# Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 use t::WASM 'no_plan';
 
 run_tests();

--- a/t/http_send_response.t
+++ b/t/http_send_response.t
@@ -1,3 +1,17 @@
+# Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 use t::WASM 'no_plan';
 
 run_tests();

--- a/t/log.t
+++ b/t/log.t
@@ -1,3 +1,17 @@
+# Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 use t::WASM 'no_plan';
 
 run_tests();

--- a/t/plugin_lifecycle.t
+++ b/t/plugin_lifecycle.t
@@ -1,3 +1,17 @@
+# Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 use t::WASM 'no_plan';
 
 run_tests();

--- a/t/property.t
+++ b/t/property.t
@@ -1,3 +1,17 @@
+# Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 use t::WASM 'no_plan';
 
 run_tests();

--- a/t/rust.t
+++ b/t/rust.t
@@ -1,3 +1,17 @@
+# Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 use t::WASM 'no_plan';
 
 run_tests();

--- a/t/testdata/README.md
+++ b/t/testdata/README.md
@@ -1,1 +1,17 @@
+<!--
+  ~ Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+-->
 Test data writtern in Go should be compiled with https://github.com/tetratelabs/proxy-wasm-go-sdk.

--- a/t/testdata/assemblyscript/assembly/index.ts
+++ b/t/testdata/assemblyscript/assembly/index.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 export * from "@solo-io/proxy-runtime/proxy"; // this exports the required functions for the proxy to interact with us.
 //this.setEffectiveContext(callback.origin_context_id);
 import {

--- a/t/testdata/assemblyscript/index.js
+++ b/t/testdata/assemblyscript/index.js
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 const fs = require("fs");
 const loader = require("@assemblyscript/loader");
 module.exports = loader.instantiateSync(fs.readFileSync(__dirname + "/build/optimized.wasm"), { /* imports */ })

--- a/t/testdata/http_call/main.go
+++ b/t/testdata/http_call/main.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 package main
 
 import (

--- a/t/testdata/http_header/main.go
+++ b/t/testdata/http_header/main.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 package main
 
 import (

--- a/t/testdata/http_lifecycle/main.go
+++ b/t/testdata/http_lifecycle/main.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 package main
 
 import (

--- a/t/testdata/http_send_response/main.go
+++ b/t/testdata/http_send_response/main.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 package main
 
 import (

--- a/t/testdata/log/main.go
+++ b/t/testdata/log/main.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 package main
 
 import (

--- a/t/testdata/plugin_lifecycle/main.go
+++ b/t/testdata/plugin_lifecycle/main.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 package main
 
 import (

--- a/t/testdata/property/get.go
+++ b/t/testdata/property/get.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 package main
 
 import (

--- a/t/testdata/property/set.go
+++ b/t/testdata/property/set.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 package main
 
 import (

--- a/t/testdata/rust/Cargo.toml
+++ b/t/testdata/rust/Cargo.toml
@@ -1,3 +1,17 @@
+# Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 [package]
 name = "fault-injection"
 version = "0.1.0"

--- a/t/testdata/rust/fault_injection.rs
+++ b/t/testdata/rust/fault_injection.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 use log::*;
 use rand::Rng;
 use serde::{Deserialize, Serialize};

--- a/utils/check-test-code-style.sh
+++ b/utils/check-test-code-style.sh
@@ -1,6 +1,18 @@
 #!/usr/bin/env bash
-
-
+# Copyright 2022 Shenzhen ZhiLiu Technology Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 set -x -euo pipefail
 
 find t -name '*.t' -exec grep -E "\-\-\-\s+(SKIP|ONLY|LAST|FIRST)$" {} + > /tmp/error.log || true


### PR DESCRIPTION
Although Apache 2 License doesn't require people to include license
header in the code, but many other repos do it. For example, ASF
requires repos under its name to do it:
https://www.apache.org/legal/src-headers.html#faq-exceptions

This PR also fix some license headers.