### PR TITLE
fix: libwasmtime.so not available under centos arm

### DIFF
--- a/install-wasmtime.sh
+++ b/install-wasmtime.sh
@@ -32,7 +32,8 @@ if [ -d wasmtime-c-api ]; then
     rm -rf wasmtime-c-api
 fi
 mv wasmtime-${VER}-${ARCH}-${os}-c-api wasmtime-c-api
-if echo "int main(void) {}" | gcc -o /dev/null -v -x c - &> /dev/stdout| grep collect | tr -s " " "\012" | grep musl; then
+if { echo "int main(void) {}" | gcc -o /dev/null -v -x c - &> /dev/stdout| grep collect | tr -s " " "\012" | grep musl; } \
+    || ( [[ -f /etc/redhat-release ]] && [[ "$arch" = "aarch64" ]] ); then
     # build from source code if the libc is musl
     git clone https://github.com/bytecodealliance/wasmtime -b ${VER} --depth 1 \
         && cd wasmtime \

--- a/install-wasmtime.sh
+++ b/install-wasmtime.sh
@@ -34,7 +34,10 @@ fi
 mv wasmtime-${VER}-${ARCH}-${os}-c-api wasmtime-c-api
 if { echo "int main(void) {}" | gcc -o /dev/null -v -x c - &> /dev/stdout| grep collect | tr -s " " "\012" | grep musl; } \
     || ( [[ -f /etc/redhat-release ]] && [[ "$arch" = "aarch64" ]] ); then
-    # build from source code if the libc is musl
+    # build from source code if the libc is musl or under centos aarch64
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+    source "$HOME/.cargo/env"
+
     git clone https://github.com/bytecodealliance/wasmtime -b ${VER} --depth 1 \
         && cd wasmtime \
         && git submodule update --init \

--- a/install-wasmtime.sh
+++ b/install-wasmtime.sh
@@ -35,8 +35,10 @@ mv wasmtime-${VER}-${ARCH}-${os}-c-api wasmtime-c-api
 if { echo "int main(void) {}" | gcc -o /dev/null -v -x c - &> /dev/stdout| grep collect | tr -s " " "\012" | grep musl; } \
     || ( [[ -f /etc/redhat-release ]] && [[ "$arch" = "aarch64" ]] ); then
     # build from source code if the libc is musl or under centos aarch64
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-    source "$HOME/.cargo/env"
+    if ! command -v cargo > /dev/null; then
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        source "$HOME/.cargo/env"
+    fi
 
     git clone https://github.com/bytecodealliance/wasmtime -b ${VER} --depth 1 \
         && cd wasmtime \


### PR DESCRIPTION
```shell
openresty: relocation error: /usr/local/openresty/wasmtime-c-api/lib/[libwasmtime.so](http://libwasmtime.so/): 
symbol __cxa_thread_atexit_impl, version GLIBC_2.18 not defined in file libc.so.6 with link time reference
```