### PR TITLE
feat: update header files to support openresty-1.23.5.1

### DIFF
--- a/gen_wasm_host_api.py
+++ b/gen_wasm_host_api.py
@@ -43,7 +43,7 @@ $header
 #ifndef NGX_HTTP_WASM_API_DEF_H
 #define NGX_HTTP_WASM_API_DEF_H
 
-
+#include <ngx_config.h>
 #include <ngx_core.h>
 
 
@@ -59,9 +59,10 @@ $header
 #define $vm_api_header_name
 
 
+#include <ngx_config.h>
+#include <ngx_core.h>
 #include <wasm.h>
 $vm_header
-#include <ngx_core.h>
 #include "proxy_wasm/proxy_wasm_types.h"
 #include "http/ngx_http_wasm_api_def.h"
 

--- a/src/http/ngx_http_wasm_api.c
+++ b/src/http/ngx_http_wasm_api.c
@@ -15,6 +15,11 @@
  *
  */
 #define _GNU_SOURCE /* for RTLD_DEFAULT */
+
+#include <ngx_config.h>
+#include <ngx_core.h>
+
+
 #include <dlfcn.h>
 #include "vm/vm.h"
 #include "ngx_http_wasm_api.h"

--- a/src/http/ngx_http_wasm_api.h
+++ b/src/http/ngx_http_wasm_api.h
@@ -17,7 +17,7 @@
 #ifndef NGX_HTTP_WASM_API_H
 #define NGX_HTTP_WASM_API_H
 
-
+#include <ngx_config.h>
 #include <ngx_core.h>
 
 

--- a/src/http/ngx_http_wasm_api_def.h
+++ b/src/http/ngx_http_wasm_api_def.h
@@ -19,7 +19,7 @@
 #ifndef NGX_HTTP_WASM_API_DEF_H
 #define NGX_HTTP_WASM_API_DEF_H
 
-
+#include <ngx_config.h>
 #include <ngx_core.h>
 
 

--- a/src/http/ngx_http_wasm_api_wasmedge.h
+++ b/src/http/ngx_http_wasm_api_wasmedge.h
@@ -19,10 +19,12 @@
 #ifndef NGX_HTTP_WASM_API_WASMEDGE_H
 #define NGX_HTTP_WASM_API_WASMEDGE_H
 
+#include <ngx_config.h>
+#include <ngx_core.h>
 
 #include <wasm.h>
 #include <wasmedge/wasmedge.h>
-#include <ngx_core.h>
+
 #include "proxy_wasm/proxy_wasm_types.h"
 #include "http/ngx_http_wasm_api_def.h"
 

--- a/src/http/ngx_http_wasm_api_wasmedge.h
+++ b/src/http/ngx_http_wasm_api_wasmedge.h
@@ -19,12 +19,11 @@
 #ifndef NGX_HTTP_WASM_API_WASMEDGE_H
 #define NGX_HTTP_WASM_API_WASMEDGE_H
 
+
 #include <ngx_config.h>
 #include <ngx_core.h>
-
 #include <wasm.h>
 #include <wasmedge/wasmedge.h>
-
 #include "proxy_wasm/proxy_wasm_types.h"
 #include "http/ngx_http_wasm_api_def.h"
 

--- a/src/http/ngx_http_wasm_api_wasmtime.h
+++ b/src/http/ngx_http_wasm_api_wasmtime.h
@@ -19,9 +19,9 @@
 #ifndef NGX_HTTP_WASM_API_WASMTIME_H
 #define NGX_HTTP_WASM_API_WASMTIME_H
 
+
 #include <ngx_config.h>
 #include <ngx_core.h>
-
 #include <wasm.h>
 #include <wasmtime.h>
 #include "proxy_wasm/proxy_wasm_types.h"

--- a/src/http/ngx_http_wasm_api_wasmtime.h
+++ b/src/http/ngx_http_wasm_api_wasmtime.h
@@ -19,10 +19,11 @@
 #ifndef NGX_HTTP_WASM_API_WASMTIME_H
 #define NGX_HTTP_WASM_API_WASMTIME_H
 
+#include <ngx_config.h>
+#include <ngx_core.h>
 
 #include <wasm.h>
 #include <wasmtime.h>
-#include <ngx_core.h>
 #include "proxy_wasm/proxy_wasm_types.h"
 #include "http/ngx_http_wasm_api_def.h"
 

--- a/src/http/ngx_http_wasm_call.h
+++ b/src/http/ngx_http_wasm_call.h
@@ -17,7 +17,8 @@
 #ifndef NGX_HTTP_WASM_CALL_H
 #define NGX_HTTP_WASM_CALL_H
 
-
+#include <ngx_config.h>
+#include <ngx_core.h>
 #include <ngx_http.h>
 
 

--- a/src/http/ngx_http_wasm_ctx.h
+++ b/src/http/ngx_http_wasm_ctx.h
@@ -17,7 +17,7 @@
 #ifndef NGX_HTTP_WASM_CTX_H
 #define NGX_HTTP_WASM_CTX_H
 
-
+#include <ngx_config.h>
 #include <ngx_core.h>
 #include "ngx_http_wasm_state.h"
 #include "proxy_wasm/proxy_wasm_types.h"

--- a/src/http/ngx_http_wasm_module.h
+++ b/src/http/ngx_http_wasm_module.h
@@ -17,7 +17,7 @@
 #ifndef NGX_HTTP_WASM_MODULE_H
 #define NGX_HTTP_WASM_MODULE_H
 
-
+#include <ngx_config.h>
 #include <ngx_core.h>
 
 

--- a/src/http/ngx_http_wasm_state.h
+++ b/src/http/ngx_http_wasm_state.h
@@ -17,7 +17,7 @@
 #ifndef NGX_HTTP_WASM_STATE_H
 #define NGX_HTTP_WASM_STATE_H
 
-
+#include <ngx_config.h>
 #include <ngx_core.h>
 #include <ngx_http.h>
 

--- a/src/proxy_wasm/proxy_wasm_map.h
+++ b/src/proxy_wasm/proxy_wasm_map.h
@@ -16,8 +16,10 @@
  */
 #ifndef PROXY_WASM_MAP_H
 #define PROXY_WASM_MAP_H
-#include <stdbool.h>
+
+#include <ngx_config.h>
 #include <ngx_core.h>
+#include <stdbool.h>
 
 
 typedef enum {

--- a/src/proxy_wasm/proxy_wasm_memory.h
+++ b/src/proxy_wasm/proxy_wasm_memory.h
@@ -16,6 +16,7 @@
  */
 #ifndef PROXY_WASM_MEMORY_H
 #define PROXY_WASM_MEMORY_H
+#include <ngx_config.h>
 #include <ngx_core.h>
 
 

--- a/src/proxy_wasm/proxy_wasm_types.h
+++ b/src/proxy_wasm/proxy_wasm_types.h
@@ -17,7 +17,7 @@
 #ifndef PROXY_WASM_TYPES_H
 #define PROXY_WASM_TYPES_H
 
-
+#include <ngx_config.h>
 #include <ngx_core.h>
 #include <ngx_http_lua_api.h>
 

--- a/src/vm/vm.h
+++ b/src/vm/vm.h
@@ -18,8 +18,9 @@
 #define VM_H
 
 
-#include <stdbool.h>
+#include <ngx_config.h>
 #include <ngx_core.h>
+#include <stdbool.h>
 
 
 #define NGX_WASM_PARAM_VOID                 1

--- a/src/vm/wasmtime.c
+++ b/src/vm/wasmtime.c
@@ -14,6 +14,9 @@
  * limitations under the License.
  *
  */
+
+#include <ngx_config.h>
+#include <ngx_core.h>
 #include <wasi.h>
 #include <wasm.h>
 #include <wasmtime.h>


### PR DESCRIPTION
when I use `build-apisix-base.sh` to compile openresty-1.23.5.1. I found an error like this: https://trac.nginx.org/nginx/ticket/2312#comment:4.
And I found a solution in https://nginx.org/en/docs/dev/development_guide.html#include_files. So I wan to change the order of header files.